### PR TITLE
ジャマイカの結果を返す関数の作成

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,28 @@
 import { useState } from 'react'
 import { Button } from '@mantine/core'
+import { calcJamaica } from './calcJamaica'
 
 function App() {
   const [count, setCount] = useState(0)
+  const [results, setResults] = useState<string[]>()
+  // const res = calcJamaica([1, 2, 3, 4, 5], 61)
+  // console.log(res)
+
+  // 入力は　答えと、数字たち
+  // 出力は、答えになる式一覧
 
   return (
     <div className='mx-auto max-w-150 w-80vw'>
       <h1 className='text-center'>Jamaica</h1>
-      <Button className='mt-10'>fff</Button>
+      <Button
+        className='mt-10'
+        onClick={() => {
+          setResults(calcJamaica([1, 2, 3, 4, 5], 61))
+        }}
+      >
+        実行
+      </Button>
+      {JSON.stringify(results)}
       <div>
         <button onClick={() => setCount(count => count + 1)}>
           count is {count}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,6 @@ import { calcJamaica } from './calcJamaica'
 function App() {
   const [count, setCount] = useState(0)
   const [results, setResults] = useState<string[]>()
-  // const res = calcJamaica([1, 2, 3, 4, 5], 61)
-  // console.log(res)
-
-  // 入力は　答えと、数字たち
-  // 出力は、答えになる式一覧
 
   return (
     <div className='mx-auto max-w-150 w-80vw'>

--- a/src/calcJamaica.ts
+++ b/src/calcJamaica.ts
@@ -1,0 +1,53 @@
+type Numbers = [number, number, number, number, number]
+
+const operators = ['+', '-', '*', '/']
+const n = 4
+
+export const calcJamaica = (numbers: Numbers, answer: number) => {
+  const results: string[] = []
+
+  // ++++, +++-, +++*, +++/, ++-+, ++*+, ++/+, ...
+  function operatorPermute(nums: Numbers, strOperators: string, len: number) {
+    // 記号が4つで計算する。 ex) res = 1+2+3+4+5
+    if (len === n) {
+      const calcFormula = `${nums[0]}${strOperators[0]}${nums[1]}${strOperators[1]}${nums[2]}${strOperators[2]}${nums[3]}${strOperators[3]}${nums[4]}`
+      const calcResult = looseJsonParse(calcFormula)
+
+      if (calcResult !== answer) return
+
+      results.push(`${calcFormula}=${calcResult}`)
+
+      return
+    }
+
+    // 1つずつ記号を取り出して、strSymbolsに追加する
+    for (let i = 0; i < n; i++) {
+      operatorPermute(nums, strOperators + operators[i], len + 1)
+    }
+  }
+
+  // 12345, 12354, 12435, 12453, ...
+  for (let a of numbers) {
+    for (let b of numbers) {
+      if (a === b) continue
+      for (let c of numbers) {
+        if (a === c || b === c) continue
+        for (let d of numbers) {
+          if (a === d || b === d || c === d) continue
+          for (let e of numbers) {
+            if (a === e || b === e || c === e || d === e) continue
+
+            operatorPermute([a, b, c, d, e], '', 0)
+          }
+        }
+      }
+    }
+  }
+
+  return results
+}
+
+// 文字列からJSの計算を実行
+function looseJsonParse(obj: any) {
+  return Function('"use strict";return (' + obj + ')')()
+}

--- a/src/calcJamaica.ts
+++ b/src/calcJamaica.ts
@@ -6,26 +6,7 @@ const n = 4
 export const calcJamaica = (numbers: Numbers, answer: number) => {
   const results: string[] = []
 
-  // ++++, +++-, +++*, +++/, ++-+, ++*+, ++/+, ...
-  function operatorPermute(nums: Numbers, strOperators: string, len: number) {
-    // 記号が4つで計算する。 ex) res = 1+2+3+4+5
-    if (len === n) {
-      const calcFormula = `${nums[0]}${strOperators[0]}${nums[1]}${strOperators[1]}${nums[2]}${strOperators[2]}${nums[3]}${strOperators[3]}${nums[4]}`
-      const calcResult = looseJsonParse(calcFormula)
-
-      if (calcResult !== answer) return
-
-      results.push(`${calcFormula}=${calcResult}`)
-
-      return
-    }
-
-    // 1つずつ記号を取り出して、strSymbolsに追加する
-    for (let i = 0; i < n; i++) {
-      operatorPermute(nums, strOperators + operators[i], len + 1)
-    }
-  }
-
+  // 数字を総当たりで並び替え
   // 12345, 12354, 12435, 12453, ...
   for (let a of numbers) {
     for (let b of numbers) {
@@ -37,10 +18,36 @@ export const calcJamaica = (numbers: Numbers, answer: number) => {
           for (let e of numbers) {
             if (a === e || b === e || c === e || d === e) continue
 
-            operatorPermute([a, b, c, d, e], '', 0)
+            operatorPermute([a, b, c, d, e])
           }
         }
       }
+    }
+  }
+
+  // 記号を総当たりで並び替え
+  // ++++, +++-, +++*, +++/, ++-+, ++*+, ++/+, ...
+  function operatorPermute(
+    nums: Numbers,
+    strOperators: string = '',
+    len: number = 0,
+  ) {
+    // 記号が4つで計算する
+    // ex) res = 1 + 2 + 3 + 4 + 5
+    if (len === 4) {
+      const calcFormula = `${nums[0]}${strOperators[0]}${nums[1]}${strOperators[1]}${nums[2]}${strOperators[2]}${nums[3]}${strOperators[3]}${nums[4]}`
+      const calcResult = looseJsonParse(calcFormula)
+
+      if (calcResult !== answer) return
+
+      results.push(`${calcFormula}=${calcResult}`)
+
+      return
+    }
+
+    // 1つずつ記号を取り出して、strSymbolsに追加して再帰する
+    for (let i = 0; i < n; i++) {
+      operatorPermute(nums, strOperators + operators[i], len + 1)
     }
   }
 


### PR DESCRIPTION
## 詳細

引数
- 数字5つ
- 求める答え

返り値
- 答えになる計算式を配列で

### 処理
1. 数字の全通りの並び替えをする
2. +-*/の並び替えをする（重複あり）
3. 数字と四則演算を合わせた文字列を生成
4. 文字列からJSの計算
5. answerと結果が同じなら、resulutsに式を追加
6. 全ての答えになる式resultsを返す

### パフォーマンス
```js
for (let a of numbers) {
```
の箇所で
```js
for (let a1=0;a1<5;a++){
  const a = numbers[a1]
```
を試したが、処理速度が変わらず長くなるだけなので`for of`にした

for of
![image](https://user-images.githubusercontent.com/88410576/222615872-bf6b8518-484f-476e-b537-3255545813ae.png)

普通のfor
![image](https://user-images.githubusercontent.com/88410576/222616025-e5a3377f-746e-41e7-a86d-10b06d9a2357.png)

### 思ったこと
全通り表示しなくていいなら、最初の一個見つけて終了した方が速くなるよね